### PR TITLE
[Team09 - 쑤 & 쏭] 게임 진행 화면 구현 (Data binding & CALayer 추가)

### DIFF
--- a/iOS/BaseballApp/BaseballApp/Controllers/LobbyViewController.swift
+++ b/iOS/BaseballApp/BaseballApp/Controllers/LobbyViewController.swift
@@ -11,23 +11,34 @@ import Combine
 class LobbyViewController: UIViewController {
 
     @IBOutlet weak var roomsTableView: UITableView!
-    var viewModel: RoomsViewModel?
-    var cancelBag = Set<AnyCancellable>()
+    var viewModel: RoomsViewModel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        roomsTableView.dataSource = self
         
         viewModel = RoomsViewModel()
-        bind()
+        viewModel.load {
+            DispatchQueue.main.async {
+                self.roomsTableView.reloadData()
+            }
+        }
     }
-    
-    func bind() {
-        viewModel?.$rooms
-            .receive(on: DispatchQueue.main)
-            .sink(receiveValue: { [weak self] _ in
-                self?.roomsTableView.reloadData()
-            })
-            .store(in: &self.cancelBag)
-    }
+   
 }
 
+extension LobbyViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return viewModel.rooms.data.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: RoomTableViewCell.identifier, for: indexPath) as? RoomTableViewCell else {
+            return UITableViewCell()
+        }
+        
+        let data = viewModel.rooms.data[indexPath.row]
+        cell.fill(data: data)
+        return cell
+    }
+}

--- a/iOS/BaseballApp/BaseballApp/Controllers/PlayViewController.swift
+++ b/iOS/BaseballApp/BaseballApp/Controllers/PlayViewController.swift
@@ -18,6 +18,7 @@ class PlayViewController: UIViewController {
     @IBOutlet weak var playInformationStackView: UIStackView!
     @IBOutlet weak var scoreHeaderView: ScoreHeaderView!
     
+    var currentPlayerView: CurrentPlayerView!
     var count: Int = 0
     var viewModel: GameViewModel! {
         didSet {
@@ -43,6 +44,9 @@ class PlayViewController: UIViewController {
             DispatchQueue.main.async { [weak self] in
                 self?.scoreHeaderView.configureAway(score: game.away_team.score)
                 self?.scoreHeaderView.configureHome(score: game.home_team.score)
+                self?.currentPlayerView.configure(batter: game.batter, status: game.batter_status)
+                self?.currentPlayerView.configure(pitcher: game.pitcher, status: game.pitcher_status)
+                self?.currentPlayerView.configure(playerRole: game.my_role)
             }
         }
     }
@@ -56,7 +60,7 @@ class PlayViewController: UIViewController {
                                                                options: nil)?.first as? CurrentPlayerView else {
             return
         }
-        
+        self.currentPlayerView = currentPlayerView
         playInformationStackView.addArrangedSubview(groundView)
         playInformationStackView.addArrangedSubview(currentPlayerView)
         playInformationStackView.addArrangedSubview(pitcherHistoryTableView)

--- a/iOS/BaseballApp/BaseballApp/Controllers/PlayViewController.swift
+++ b/iOS/BaseballApp/BaseballApp/Controllers/PlayViewController.swift
@@ -18,11 +18,10 @@ class PlayViewController: UIViewController {
     @IBOutlet weak var playInformationStackView: UIStackView!
     @IBOutlet weak var scoreHeaderView: ScoreHeaderView!
     
-    var cancelBag = Set<AnyCancellable>()
     var count: Int = 0
-    var viewModel: GameViewModel? {
+    var viewModel: GameViewModel! {
         didSet {
-            count = viewModel?.game?.pitcherHistory.count ?? 0
+            count = viewModel?.game?.data.pitch_histories.count ?? 0
         }
     }
     
@@ -40,17 +39,12 @@ class PlayViewController: UIViewController {
         
         viewModel = GameViewModel()
         configureUI()
-    }
-    
-    // MARK: - Private Functions
-    private func bind() {
-        viewModel?.$game
-            .receive(on: DispatchQueue.main)
-            .sink(receiveValue: { [weak self] game in
-                self?.scoreHeaderView.configureAway(score: game?.away.score ?? 0)
-                self?.scoreHeaderView.configureHome(score: game?.home.score ?? 0)
-            })
-            .store(in: &self.cancelBag)
+        viewModel.load { game in
+            DispatchQueue.main.async { [weak self] in
+                self?.scoreHeaderView.configureAway(score: game.away_team.score)
+                self?.scoreHeaderView.configureHome(score: game.home_team.score)
+            }
+        }
     }
     
     private func configureUI() {
@@ -79,12 +73,12 @@ class PlayViewController: UIViewController {
 
 extension PlayViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel?.game?.pitcherHistory.count ?? 0
+        return viewModel?.game?.data.pitch_histories.count ?? 0
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: PitcherRecordTableViewCell.identifier, for: indexPath) as! PitcherRecordTableViewCell
-        cell.backgroundColor = .systemRed
+        
         return cell
     }
 }

--- a/iOS/BaseballApp/BaseballApp/Controllers/PlayViewController.swift
+++ b/iOS/BaseballApp/BaseballApp/Controllers/PlayViewController.swift
@@ -47,6 +47,7 @@ class PlayViewController: UIViewController {
                 self?.currentPlayerView.configure(batter: game.batter, status: game.batter_status)
                 self?.currentPlayerView.configure(pitcher: game.pitcher, status: game.pitcher_status)
                 self?.currentPlayerView.configure(playerRole: game.my_role)
+                self?.pitcherHistoryTableView.reloadData()
             }
         }
     }
@@ -81,8 +82,11 @@ extension PlayViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: PitcherRecordTableViewCell.identifier, for: indexPath) as! PitcherRecordTableViewCell
-        
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: PitcherRecordTableViewCell.identifier, for: indexPath) as? PitcherRecordTableViewCell,
+              let record = viewModel.game?.data.pitch_histories[indexPath.row] else {
+            return UITableViewCell()
+        }
+        cell.configure(record: record)
         return cell
     }
 }

--- a/iOS/BaseballApp/BaseballApp/Controllers/PlayViewController.swift
+++ b/iOS/BaseballApp/BaseballApp/Controllers/PlayViewController.swift
@@ -22,7 +22,7 @@ class PlayViewController: UIViewController {
     var count: Int = 0
     var viewModel: GameViewModel! {
         didSet {
-            count = viewModel?.game?.data.pitch_histories.count ?? 0
+            count = viewModel?.game?.data.pitchHistories.count ?? 0
         }
     }
     
@@ -42,11 +42,11 @@ class PlayViewController: UIViewController {
         configureUI()
         viewModel.load { game in
             DispatchQueue.main.async { [weak self] in
-                self?.scoreHeaderView.configureAway(score: game.away_team.score)
-                self?.scoreHeaderView.configureHome(score: game.home_team.score)
-                self?.currentPlayerView.configure(batter: game.batter, status: game.batter_status)
-                self?.currentPlayerView.configure(pitcher: game.pitcher, status: game.pitcher_status)
-                self?.currentPlayerView.configure(playerRole: game.my_role)
+                self?.scoreHeaderView.configureAway(score: game.awayTeam.score)
+                self?.scoreHeaderView.configureHome(score: game.homeTeam.score)
+                self?.currentPlayerView.configure(batter: game.batter, status: game.batterStatus)
+                self?.currentPlayerView.configure(pitcher: game.pitcher, status: game.pitcherStatus)
+                self?.currentPlayerView.configure(playerRole: game.myRole)
                 self?.pitcherHistoryTableView.reloadData()
             }
         }
@@ -78,12 +78,12 @@ class PlayViewController: UIViewController {
 
 extension PlayViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel?.game?.data.pitch_histories.count ?? 0
+        return viewModel?.game?.data.pitchHistories.count ?? 0
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: PitcherRecordTableViewCell.identifier, for: indexPath) as? PitcherRecordTableViewCell,
-              let record = viewModel.game?.data.pitch_histories[indexPath.row] else {
+              let record = viewModel.game?.data.pitchHistories[indexPath.row] else {
             return UITableViewCell()
         }
         cell.configure(record: record)

--- a/iOS/BaseballApp/BaseballApp/Entity/Game.swift
+++ b/iOS/BaseballApp/BaseballApp/Entity/Game.swift
@@ -7,36 +7,47 @@
 
 import Foundation
 
+struct GameResponse: Decodable {
+    let data: Game
+}
+
 struct Game: Decodable {
-    let home: Team
-    let away: Team
     let strike: Int
     let ball: Int
     let out: Int
+    let away_team: Team
+    let home_team: Team
     let inning: String
-    let myRole: String
+    let halves: String
+    let pitcher: Player
+    let pitcher_status: String
+    let batter: Player
+    let batter_status: String
     let base1: String?
     let base2: String?
     let base3: String?
-    let pitcherHistory: [Record]
+    let pitch_histories: [Record]
+    let my_role: String
+}
+
+struct Player: Decodable {
+    let team_id: Int
+    let uniform_number: Int
+    let name: String
 }
 
 struct Record: Decodable {
+    let pitcher: Player
+    let batter: Player
     let result: String
-    let pitchStrikeCount: String
-    
-    enum CodingKeys: String, CodingKey {
-        case result
-        case pitchStrikeCount = "log"
-    }
+    let strike_count: Int
+    let ball_count: Int
 }
 
 struct Team: Decodable {
     let name: String
     let score: Int
-    let position: String
-    let player: String
-    let playerStatus: String
+    let role: String
 }
 
 struct Scoreboard: Decodable {

--- a/iOS/BaseballApp/BaseballApp/Entity/Game.swift
+++ b/iOS/BaseballApp/BaseballApp/Entity/Game.swift
@@ -15,33 +15,55 @@ struct Game: Decodable {
     let strike: Int
     let ball: Int
     let out: Int
-    let away_team: Team
-    let home_team: Team
+    let awayTeam: Team
+    let homeTeam: Team
     let inning: String
     let halves: String
     let pitcher: Player
-    let pitcher_status: String
+    let pitcherStatus: String
     let batter: Player
-    let batter_status: String
+    let batterStatus: String
     let base1: String?
     let base2: String?
     let base3: String?
-    let pitch_histories: [Record]
-    let my_role: String
+    let pitchHistories: [Record]
+    let myRole: String
+    
+    enum CodingKeys: String, CodingKey {
+        case strike, ball, out, inning, halves, pitcher, batter, base1, base2, base3
+        case awayTeam = "away_team"
+        case homeTeam = "home_team"
+        case pitcherStatus = "pitcher_status"
+        case batterStatus = "batter_status"
+        case pitchHistories = "pitch_histories"
+        case myRole = "my_role"
+    }
 }
 
 struct Player: Decodable {
-    let team_id: Int
-    let uniform_number: Int
+    let teamId: Int
+    let uniformNumber: Int
     let name: String
+    
+    enum CodingKeys: String, CodingKey {
+        case name
+        case teamId = "team_id"
+        case uniformNumber = "uniform_number"
+    }
 }
 
 struct Record: Decodable {
     let pitcher: Player
     let batter: Player
     let result: String
-    let strike_count: Int
-    let ball_count: Int
+    let strikeCount: Int
+    let ballCount: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case pitcher, batter, result
+        case strikeCount = "strike_count"
+        case ballCount = "ball_count"
+    }
 }
 
 struct Team: Decodable {

--- a/iOS/BaseballApp/BaseballApp/Entity/Room.swift
+++ b/iOS/BaseballApp/BaseballApp/Entity/Room.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 struct RoomResponse: Decodable {
-    let rooms: [Room]
+    let data: [Room]
 }
 
 struct Room: Decodable {
     let id: Int
-    let number: String
-    let away: String
-    let home: String
-    let available: Bool
+    let awayTeam: String?
+    let homeTeam: String?
+    let awayUserEmail: String?
+    let homeUserEmail: String?
 }

--- a/iOS/BaseballApp/BaseballApp/Network/APIRequestManager.swift
+++ b/iOS/BaseballApp/BaseballApp/Network/APIRequestManager.swift
@@ -9,7 +9,6 @@ import Foundation
 import Combine
 
 class APIRequestManager {
-    private var cancelBag = Set<AnyCancellable>()
     
     private func createRequest(url: URL, method: HTTPMethod, httpBody: Data? = nil) -> URLRequest {
         var request = URLRequest(url: url)
@@ -17,33 +16,27 @@ class APIRequestManager {
         request.httpBody = httpBody
         return request
     }
-    
-    func fetchRooms(url: URL, method: HTTPMethod, httpBody: Data? = nil) {
+  
+    func fetch<T: Decodable>(url: URL, method: HTTPMethod, httpBody: Data? = nil) -> AnyPublisher<T, Error> {
         let request = createRequest(url: url, method: method)
-        URLSession.shared.dataTaskPublisher(for: request)
+        return URLSession.shared.dataTaskPublisher(for: request)
             .map(\.data)
-            .decode(type: RoomResponse.self, decoder: JSONDecoder())
-            .replaceError(with: RoomResponse(rooms: []))
-            .assign(to: \.rooms, on: RoomsViewModel())
-            .store(in: &self.cancelBag)
-    }
-    
-    func fetchGame(url: URL, method: HTTPMethod, httpBody: Data? = nil) {
-        let request = createRequest(url: url, method: method)
-        URLSession.shared.dataTaskPublisher(for: request)
-            .map(\.data)
-            .decode(type: Game?.self, decoder: JSONDecoder())
-            .replaceError(with: nil)
-            .assign(to: \.game, on: GameViewModel())
-            .store(in: &self.cancelBag)
+            .decode(type: T.self, decoder: JSONDecoder())
+            .eraseToAnyPublisher()
     }
 }
 
 struct Endpoint {
+    enum Path {
+        static let gameList = "/game/list"
+        static let gameStatus = "/game/status"
+    }
+    
     static func url(path: String) -> URL? {
         var components = URLComponents()
-        components.scheme = "https"
-        components.host = "api.github.com"
+        components.scheme = "http"
+        components.host = "52.78.19.43"
+        components.port = 8080
         components.path = path
         return components.url
     }

--- a/iOS/BaseballApp/BaseballApp/UseCases/GameUseCase.swift
+++ b/iOS/BaseballApp/BaseballApp/UseCases/GameUseCase.swift
@@ -6,11 +6,12 @@
 //
 
 import Foundation
+import Combine
 
 class GameUseCase {
     let apiRequestManager = APIRequestManager()
     
-    func start(url: URL) {
-        apiRequestManager.fetchGame(url: url, method: .get)
+    func start(url: URL) -> AnyPublisher<GameResponse, Error> {
+        return apiRequestManager.fetch(url: url, method: .get)
     }
 }

--- a/iOS/BaseballApp/BaseballApp/UseCases/RoomsUseCase.swift
+++ b/iOS/BaseballApp/BaseballApp/UseCases/RoomsUseCase.swift
@@ -6,11 +6,12 @@
 //
 
 import Foundation
+import Combine
 
 class RoomsUseCase {
     let apiRequestManager = APIRequestManager()
     
-    func start(url: URL) {
-        apiRequestManager.fetchRooms(url: url, method: .get)
+    func start(url: URL) -> AnyPublisher<RoomResponse, Error> {
+        return apiRequestManager.fetch(url: url, method: .get)
     }
 }

--- a/iOS/BaseballApp/BaseballApp/ViewModel/GameViewModel.swift
+++ b/iOS/BaseballApp/BaseballApp/ViewModel/GameViewModel.swift
@@ -6,22 +6,35 @@
 //
 
 import Foundation
+import Combine
 
 class GameViewModel {
-    @Published var game: Game?
-    
+    @Published var game: GameResponse?
     let gameUseCase = GameUseCase()
+    var cancelBag = Set<AnyCancellable>()
     
-    func load() {
-        guard let url = Endpoint.url(path: "/room/playInfo") else { return }
-        gameUseCase.start(url: url)
+    func load(completionHandler: @escaping (Game) -> Void) {
+        guard let url = Endpoint.url(path: Endpoint.Path.gameStatus) else { return }
+        let publisher = gameUseCase.start(url: url)
+        publisher.sink { (completion) in
+            switch completion {
+            case .finished:
+                break
+            case .failure(let error):
+                print(error.localizedDescription)
+            }
+        } receiveValue: { (response) in
+            self.game = response
+            completionHandler(response.data)
+        }
+        .store(in: &cancelBag)
     }
     
     func getAwayScore() -> Int {
-        return game?.away.score ?? 0
+        return game?.data.away_team.score ?? 0
     }
     
     func getHomeScore() -> Int {
-        return game?.home.score ?? 0
+        return game?.data.home_team.score ?? 0
     }
 }

--- a/iOS/BaseballApp/BaseballApp/ViewModel/GameViewModel.swift
+++ b/iOS/BaseballApp/BaseballApp/ViewModel/GameViewModel.swift
@@ -29,12 +29,4 @@ class GameViewModel {
         }
         .store(in: &cancelBag)
     }
-    
-    func getAwayScore() -> Int {
-        return game?.data.away_team.score ?? 0
-    }
-    
-    func getHomeScore() -> Int {
-        return game?.data.home_team.score ?? 0
-    }
 }

--- a/iOS/BaseballApp/BaseballApp/Views/Base.lproj/Main.storyboard
+++ b/iOS/BaseballApp/BaseballApp/Views/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="z87-J8-Gpn">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -30,7 +30,7 @@
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="RoomTableViewCell" rowHeight="128" id="6g6-nx-YgT" customClass="RoomTableViewCell" customModule="BaseballApp" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="24.5" width="414" height="128"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="128"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="6g6-nx-YgT" id="cIk-9u-0ic">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="128"/>

--- a/iOS/BaseballApp/BaseballApp/Views/Base.lproj/Main.storyboard
+++ b/iOS/BaseballApp/BaseballApp/Views/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="z87-J8-Gpn">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>

--- a/iOS/BaseballApp/BaseballApp/Views/CurrentPlayerView.swift
+++ b/iOS/BaseballApp/BaseballApp/Views/CurrentPlayerView.swift
@@ -31,11 +31,11 @@ class CurrentPlayerView: UIView {
     
     func configure(playerRole: String) {
         if playerRole == Role.DEFENSE {
-            isBatter.isHidden = false
-            isPitcher.isHidden = true
-        } else {
             isBatter.isHidden = true
             isPitcher.isHidden = false
+        } else {
+            isBatter.isHidden = false
+            isPitcher.isHidden = true
         }
     }
 }

--- a/iOS/BaseballApp/BaseballApp/Views/CurrentPlayerView.swift
+++ b/iOS/BaseballApp/BaseballApp/Views/CurrentPlayerView.swift
@@ -7,4 +7,35 @@
 
 import UIKit
 
-class CurrentPlayerView: UIView { }
+class CurrentPlayerView: UIView {
+    @IBOutlet weak var pitcher: UILabel!
+    @IBOutlet weak var pitcherStatus: UILabel!
+    @IBOutlet weak var isPitcher: UIImageView!
+    @IBOutlet weak var batter: UILabel!
+    @IBOutlet weak var batterStatus: UILabel!
+    @IBOutlet weak var isBatter: UIImageView!
+    
+    enum Role {
+        static let DEFENSE = "DEFENSE"
+    }
+    
+    func configure(pitcher: Player, status: String) {
+        self.pitcher.text = pitcher.name
+        self.pitcherStatus.text = status
+    }
+    
+    func configure(batter: Player, status: String) {
+        self.batter.text = batter.name
+        self.batterStatus.text = status
+    }
+    
+    func configure(playerRole: String) {
+        if playerRole == Role.DEFENSE {
+            isBatter.isHidden = false
+            isPitcher.isHidden = true
+        } else {
+            isBatter.isHidden = true
+            isPitcher.isHidden = false
+        }
+    }
+}

--- a/iOS/BaseballApp/BaseballApp/Views/CurrentPlayerView.xib
+++ b/iOS/BaseballApp/BaseballApp/Views/CurrentPlayerView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -108,6 +108,14 @@
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="H8G-KW-oqg" secondAttribute="trailing" constant="10" id="wDP-Ok-pev"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="batter" destination="cC0-Do-66U" id="g97-pG-TyF"/>
+                <outlet property="batterStatus" destination="BDu-3i-7gZ" id="ixQ-hj-ubq"/>
+                <outlet property="isBatter" destination="VhL-eN-0e9" id="crv-Sb-YDk"/>
+                <outlet property="isPitcher" destination="Lzr-Dd-4HD" id="j5X-6s-PEe"/>
+                <outlet property="pitcher" destination="Fuc-eJ-GRX" id="pIi-9F-dwl"/>
+                <outlet property="pitcherStatus" destination="BBD-Lj-MPd" id="KOw-3y-fC4"/>
+            </connections>
             <point key="canvasLocation" x="84.057971014492765" y="-135.60267857142856"/>
         </view>
     </objects>

--- a/iOS/BaseballApp/BaseballApp/Views/GroundView.swift
+++ b/iOS/BaseballApp/BaseballApp/Views/GroundView.swift
@@ -8,89 +8,99 @@
 import UIKit
 
 class GroundView: UIView {
-    let infieldSquareLayer = CAShapeLayer()
-    let homePlateLayer = CAShapeLayer()
-    let firstBaseLayer = CAShapeLayer()
-    let secondBaseLayer = CAShapeLayer()
-    let thirdBaseLayer = CAShapeLayer()
+    enum Constant {
+        static let infieldSquareLineWidth: CGFloat = 5.0
+        static let baseLineWidth: CGFloat = 1.0
+        static let padding: CGFloat = 50.0
+        static let baseDiagonalLength: CGFloat = 30.0
+    }
+    
+    private let infieldSquareLayer = CAShapeLayer()
+    private let homePlateLayer = CAShapeLayer()
+    private var firstBaseLayer = CAShapeLayer()
+    private var secondBaseLayer = CAShapeLayer()
+    private var thirdBaseLayer = CAShapeLayer()
     
     override func awakeFromNib() {
         self.backgroundColor = .systemGray3
-        addLine()
-    }
-    
-    func addLine() {
-        layer.addSublayer(infieldSquareLayer)
-        infieldSquareLayer.strokeColor = UIColor.systemGray.cgColor
-        infieldSquareLayer.fillColor = UIColor.clear.cgColor
-        infieldSquareLayer.lineWidth = 5.0
-        //shapeLayer.strokeEnd = 1
-        
-        layer.addSublayer(homePlateLayer)
-        homePlateLayer.fillColor = UIColor.white.cgColor
-        
-        layer.addSublayer(firstBaseLayer)
-        firstBaseLayer.strokeColor = UIColor.systemGray.cgColor
-        firstBaseLayer.fillColor = UIColor.white.cgColor
-        firstBaseLayer.lineWidth = 1.0
-        
-        layer.addSublayer(secondBaseLayer)
-        secondBaseLayer.strokeColor = UIColor.systemGray.cgColor
-        secondBaseLayer.fillColor = UIColor.white.cgColor
-        secondBaseLayer.lineWidth = 1.0
-        
-        layer.addSublayer(thirdBaseLayer)
-        thirdBaseLayer.strokeColor = UIColor.systemGray.cgColor
-        thirdBaseLayer.fillColor = UIColor.white.cgColor
-        thirdBaseLayer.lineWidth = 1.0
     }
     
     override func layoutSubviews() {
         super.layoutSubviews()
         
-        let squarePath = UIBezierPath()
-        /// Home Plate
-        squarePath.move(to: CGPoint(x: bounds.midX, y: bounds.maxY - 50.0))
-        /// First Plate
-        squarePath.addLine(to: CGPoint(x: bounds.maxX - 50.0, y: bounds.midY))
-        /// Second Plate
-        squarePath.addLine(to: CGPoint(x: bounds.midX, y: bounds.minY + 50.0))
-        /// Third Plate
-        squarePath.addLine(to: CGPoint(x: bounds.minX + 50.0, y: bounds.midY))
-        squarePath.close()
-        infieldSquareLayer.path = squarePath.cgPath
+        configureInfieldSquareLayer()
+        configureHomePlateLayer()
+        configureLayerForBases()
+    }
+    
+    private func configureInfieldSquareLayer() {
+        infieldSquareLayer.frame = CGRect(x: bounds.minX + Constant.padding,
+                                          y: bounds.minY + Constant.padding,
+                                          width: bounds.width - (Constant.padding * 2),
+                                          height: bounds.height - (Constant.padding * 2))
+        layer.addSublayer(infieldSquareLayer)
+        infieldSquareLayer.strokeColor = UIColor.systemGray.cgColor
+        infieldSquareLayer.fillColor = UIColor.clear.cgColor
+        infieldSquareLayer.lineWidth = Constant.infieldSquareLineWidth
+    }
+    
+    private func configureHomePlateLayer() {
+        homePlateLayer.frame = CGRect(x: bounds.midX - 15.0,
+                                      y: bounds.maxY - 70.0,
+                                      width: 30.0,
+                                      height: 45.0)
+        layer.addSublayer(homePlateLayer)
+        homePlateLayer.fillColor = UIColor.white.cgColor
+    }
+    
+    private func configureLayerForBases() {
+        firstBaseLayer = createBaseLayer(origin: CGPoint(x: bounds.maxX - Constant.padding - Constant.baseDiagonalLength / 2,
+                                                      y: bounds.midY - Constant.baseDiagonalLength / 2))
+        secondBaseLayer = createBaseLayer(origin: CGPoint(x: bounds.midX - Constant.baseDiagonalLength / 2,
+                                                          y: bounds.minY + Constant.padding - Constant.baseDiagonalLength / 2))
+        thirdBaseLayer = createBaseLayer(origin: CGPoint(x: bounds.minX + Constant.padding - Constant.baseDiagonalLength / 2,
+                                                         y: bounds.midY - Constant.baseDiagonalLength / 2))
         
+        infieldSquareLayer.path = createRhombusPath(for: infieldSquareLayer)
+        homePlateLayer.path = createPlatePath(for: homePlateLayer)
+        firstBaseLayer.path = createRhombusPath(for: firstBaseLayer)
+        secondBaseLayer.path = createRhombusPath(for: secondBaseLayer)
+        thirdBaseLayer.path = createRhombusPath(for: thirdBaseLayer)
+    }
+    
+    private func createRhombusPath(for layer: CAShapeLayer) -> CGPath {
+        let rhombusPath = UIBezierPath()
+        rhombusPath.move(to: CGPoint(x: layer.bounds.midX, y: layer.bounds.maxY))
+        rhombusPath.addLine(to: CGPoint(x: layer.bounds.minX, y: layer.bounds.midY))
+        rhombusPath.addLine(to: CGPoint(x: layer.bounds.midX, y: layer.bounds.minY))
+        rhombusPath.addLine(to: CGPoint(x: layer.bounds.maxX, y: layer.bounds.midY))
+        rhombusPath.close()
+        return rhombusPath.cgPath
+    }
+    
+    private func createPlatePath(for layer: CAShapeLayer) -> CGPath {
         let platePath = UIBezierPath()
-        platePath.move(to: CGPoint(x: bounds.midX, y: bounds.maxY - 70.0))
-        platePath.addLine(to: CGPoint(x: bounds.midX - 15.0, y: bounds.maxY - 55.0))
-        platePath.addLine(to: CGPoint(x: bounds.midX - 15.0, y: bounds.maxY - 25.0))
-        platePath.addLine(to: CGPoint(x: bounds.midX + 15.0, y: bounds.maxY - 25.0))
-        platePath.addLine(to: CGPoint(x: bounds.midX + 15.0, y: bounds.maxY - 55.0))
+        platePath.move(to: CGPoint(x: layer.bounds.midX, y: layer.bounds.minY))
+        platePath.addLine(to: CGPoint(x: layer.bounds.minX, y: layer.bounds.minY + 15.0))
+        platePath.addLine(to: CGPoint(x: layer.bounds.minX, y: layer.bounds.minY + 15.0 + 30.0))
+        platePath.addLine(to: CGPoint(x: layer.bounds.midX + 15.0, y: layer.bounds.minY + 15.0 + 30.0))
+        platePath.addLine(to: CGPoint(x: layer.bounds.midX + 15.0, y: layer.bounds.minY + 15.0))
         platePath.close()
-        homePlateLayer.path = platePath.cgPath
-        
-        let firstBasePath = UIBezierPath()
-        firstBasePath.move(to: CGPoint(x: bounds.maxX - 65.0, y: bounds.midY))
-        firstBasePath.addLine(to: CGPoint(x: bounds.maxX - 50.0, y: bounds.midY - 15.0))
-        firstBasePath.addLine(to: CGPoint(x: bounds.maxX - 35.0, y: bounds.midY))
-        firstBasePath.addLine(to: CGPoint(x: bounds.maxX - 50.0, y: bounds.midY + 15.0))
-        firstBasePath.close()
-        firstBaseLayer.path = firstBasePath.cgPath
-        
-        let secondBasePath = UIBezierPath()
-        secondBasePath.move(to: CGPoint(x: bounds.midX - 15.0, y: bounds.minY + 50.0))
-        secondBasePath.addLine(to: CGPoint(x: bounds.midX, y: bounds.minY + 35.0))
-        secondBasePath.addLine(to: CGPoint(x: bounds.midX + 15.0, y: bounds.minY + 50.0))
-        secondBasePath.addLine(to: CGPoint(x: bounds.midX, y: bounds.minY + 65.0))
-        secondBasePath.close()
-        secondBaseLayer.path = secondBasePath.cgPath
-        
-        let thirdBasePath = UIBezierPath()
-        thirdBasePath.move(to: CGPoint(x: bounds.minX + 35.0, y: bounds.midY))
-        thirdBasePath.addLine(to: CGPoint(x: bounds.minX + 50.0, y: bounds.midY - 15.0))
-        thirdBasePath.addLine(to: CGPoint(x: bounds.minX + 65.0, y: bounds.midY))
-        thirdBasePath.addLine(to: CGPoint(x: bounds.minX + 50.0, y: bounds.midY + 15.0))
-        thirdBasePath.close()
-        thirdBaseLayer.path = thirdBasePath.cgPath
+        return platePath.cgPath
+    }
+    
+    private func createBaseLayer(origin: CGPoint) -> CAShapeLayer {
+        let baseLayer = CAShapeLayer()
+        baseLayer.frame = CGRect(origin: origin,
+                                 size: CGSize(width: Constant.baseDiagonalLength, height: Constant.baseDiagonalLength))
+        layer.addSublayer(baseLayer)
+        baseLayer.strokeColor = UIColor.systemGray.cgColor
+        baseLayer.fillColor = UIColor.white.cgColor
+        baseLayer.lineWidth = Constant.baseLineWidth
+        return baseLayer
+    }
+    
+    @IBAction func pitchButtonPressed(_ sender: UIButton) {
+            
     }
 }

--- a/iOS/BaseballApp/BaseballApp/Views/GroundView.xib
+++ b/iOS/BaseballApp/BaseballApp/Views/GroundView.xib
@@ -11,7 +11,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="GroundView" customModule="BaseballApp" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="603" height="604"/>
+            <rect key="frame" x="0.0" y="0.0" width="390" height="390"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="0pe-Ky-1je">
@@ -107,19 +107,19 @@
                     </subviews>
                 </stackView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2회초" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gNx-MW-ziO">
-                    <rect key="frame" x="497.5" y="54" width="56.5" height="29"/>
+                    <rect key="frame" x="284.5" y="54" width="56.5" height="29"/>
                     <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="수비" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9mI-HW-KUF">
-                    <rect key="frame" x="512" y="91" width="42" height="29"/>
+                    <rect key="frame" x="299" y="91" width="42" height="29"/>
                     <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7tM-DG-9So">
-                    <rect key="frame" x="256.5" y="279.5" width="90" height="45"/>
+                    <rect key="frame" x="150" y="172.5" width="90" height="45"/>
                     <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="90" id="1ry-k3-blT"/>
@@ -135,6 +135,9 @@
                             <integer key="value" value="15"/>
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="pitchButtonPressed:" destination="iN0-l3-epB" eventType="touchUpInside" id="FZs-F0-zSc"/>
+                    </connections>
                 </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>

--- a/iOS/BaseballApp/BaseballApp/Views/PitcherRecordTableViewCell.swift
+++ b/iOS/BaseballApp/BaseballApp/Views/PitcherRecordTableViewCell.swift
@@ -23,8 +23,8 @@ class PitcherRecordTableViewCell: UITableViewCell {
     
     func configure(record: Record) {
         result.text = record.result
-        let strike = record.strike_count
-        let ball = record.ball_count
+        let strike = record.strikeCount
+        let ball = record.ballCount
         count.text = "\(strike)-\(ball)"
     }
 }

--- a/iOS/BaseballApp/BaseballApp/Views/PitcherRecordTableViewCell.swift
+++ b/iOS/BaseballApp/BaseballApp/Views/PitcherRecordTableViewCell.swift
@@ -9,6 +9,8 @@ import UIKit
 
 class PitcherRecordTableViewCell: UITableViewCell {
     @IBOutlet weak var numberLabel: UILabel!
+    @IBOutlet weak var result: UILabel!
+    @IBOutlet weak var count: UILabel!
 
     static func nib() -> UINib {
         return UINib(nibName: self.identifier, bundle: nil)
@@ -17,5 +19,12 @@ class PitcherRecordTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         numberLabel.layer.masksToBounds = true
         numberLabel.layer.cornerRadius = numberLabel.frame.width / 2
+    }
+    
+    func configure(record: Record) {
+        result.text = record.result
+        let strike = record.strike_count
+        let ball = record.ball_count
+        count.text = "\(strike)-\(ball)"
     }
 }

--- a/iOS/BaseballApp/BaseballApp/Views/PitcherRecordTableViewCell.xib
+++ b/iOS/BaseballApp/BaseballApp/Views/PitcherRecordTableViewCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -51,7 +51,9 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="count" destination="Cfb-F8-KY2" id="23r-F7-lyR"/>
                 <outlet property="numberLabel" destination="ela-Yw-Z7Q" id="zap-El-UKs"/>
+                <outlet property="result" destination="ZFG-uF-TI3" id="zxV-ib-l3h"/>
             </connections>
             <point key="canvasLocation" x="86.956521739130437" y="101.78571428571428"/>
         </tableViewCell>

--- a/iOS/BaseballApp/BaseballApp/Views/RoomTableViewCell.swift
+++ b/iOS/BaseballApp/BaseballApp/Views/RoomTableViewCell.swift
@@ -13,4 +13,9 @@ class RoomTableViewCell: UITableViewCell {
     @IBOutlet weak var awayTeamName: UILabel!
     @IBOutlet weak var homeTeamName: UILabel!
 
+    func fill(data: Room) {
+        roomNumber.text = "\(data.id)"
+        awayTeamName.text = data.awayTeam
+        homeTeamName.text = data.homeTeam
+    }
 }


### PR DESCRIPTION
## 작업 목록
- [x] Combine 이용해 제목, 투수 및 타자 정보, 볼카운트 리스트 정보 binding
- [x] 진행현황판에 요소(1루, 2루, 홈플레이트 등) CALayer 및 UIBezierPath로 구현

## 학습 키워드
- Combine
- Generic
- CALayer
- UIBezierPath

## 고민과 해결
- 지난 1차 PR에서 고민으로 말씀드렸던 Generic으로 함수를 추상화하는 부분을 개선해보았습니다. assign 메소드 대신 AnyPublisher를 리턴하고 그렇게 함으로써 ViewController 대신 ViewModel 안에서 데이터를 Binding 하는 방향으로 구현이 되었습니다.
- CALayer나 UIBezierPath 관련 부분을 코드로 모두 작성하다 보니 파일이 길어지는 것 같아 중복되는 부분을 메소드로 묶어줄 수 있도록 신경 썼습니다.